### PR TITLE
Replace deprecated :crypto.hmac

### DIFF
--- a/lib/ex_airtable/table_cache.ex
+++ b/lib/ex_airtable/table_cache.ex
@@ -258,8 +258,8 @@ defmodule ExAirtable.TableCache do
   end
 
   defp generate_hash(items) do
-    :sha256
-    |> :crypto.hmac(@cache_secret, :erlang.term_to_binary(items))
+    :hmac
+    |> :crypto.mac(:sha256, @cache_secret, :erlang.term_to_binary(items))
     |> Base.encode64()
   end
 


### PR DESCRIPTION
Hi @exploration,

The :crypto.hmac/3 was deprecated and deleted in OTP-24, replacing it with :crypto.mac/4 as suggested [here](http://erlang.org/doc/general_info/deprecations.html). Google remembers [more precisely] :) (http://webcache.googleusercontent.com/search?q=cache:9bq_tglecwUJ:erlang.org/doc/general_info/deprecations.html+&cd=2&hl=en&ct=clnk).

Thank you for the great package!