### PR TITLE
Fix bug preventing update from overwriting existing data

### DIFF
--- a/lib/ex_airtable/service.ex
+++ b/lib/ex_airtable/service.ex
@@ -114,8 +114,8 @@ defmodule ExAirtable.Service do
   """
   def update(%Config.Table{} = table, %Airtable.List{} = list, opts \\ []) do
     method =
-      case Keyword.fetch!(opts, :overwrite) do
-        true -> :put
+      case Keyword.fetch(opts, :overwrite) do
+        {:ok, true} -> :put
         _ -> :patch
       end
 

--- a/lib/ex_airtable/service.ex
+++ b/lib/ex_airtable/service.ex
@@ -114,7 +114,7 @@ defmodule ExAirtable.Service do
   """
   def update(%Config.Table{} = table, %Airtable.List{} = list, opts \\ []) do
     method =
-      case Keyword.fetch(opts, :overwrite) do
+      case Keyword.fetch!(opts, :overwrite) do
         true -> :put
         _ -> :patch
       end


### PR DESCRIPTION
According to its documentation, `Service.update/3` uses a PUT request when `:overwrite` is set to `true` in its Keyword list of options. This will "overwrite all values in the destination record with values being sent".

But because `Keyword.fetch/2` is used instead of `Keyword.fetch!/2`, `:overwrite` will never pattern-match on `true`, only `{:ok, true}`. So it is always interpreted as `false`, forcing a PATCH request.

Given that `Keyword.fetch!/2` is used throughout the code with its risk of raising errors, I first assumed it was intended here. But best to use safer code in second commit, which I think was the actual intent here.