### PR TITLE
Support new "delete multiple records" API endpoint

### DIFF
--- a/lib/ex_airtable.ex
+++ b/lib/ex_airtable.ex
@@ -157,9 +157,9 @@ defmodule ExAirtable do
   end
 
   @doc """
-  Delete a single record (by ID) from an Airtable.
+  Delete a single record or list of records by ID from an Airtable.
 
-  If successful, the record will be deleted from the cache as well.
+  If successful, the records will be deleted from the cache as well.
 
   This call is asynchronous, but the local cache will be automatically updated when the callback is successful.
   """
@@ -171,6 +171,19 @@ defmodule ExAirtable do
       )
 
     RateLimiter.request(table_module, job)
+  end
+
+  def delete(table_module, list) when is_list(list) do
+    Enum.chunk_every(list, 10)
+    |> Enum.each(fn ids ->
+      job =
+        Request.create(
+          {table_module, :delete, [ids]},
+          {TableCache, :delete, [table_module]}
+        )
+
+      RateLimiter.request(table_module, job)
+    end)
   end
 
   @doc """

--- a/lib/ex_airtable/service.ex
+++ b/lib/ex_airtable/service.ex
@@ -52,7 +52,7 @@ defmodule ExAirtable.Service do
   end
 
   @doc """
-  Delete a single record (by ID) from an Airtable.
+  Delete a single record or list of records by ID from an Airtable.
 
   Returns a custom map on success - see below.
 

--- a/lib/ex_airtable/service.ex
+++ b/lib/ex_airtable/service.ex
@@ -62,7 +62,13 @@ defmodule ExAirtable.Service do
       %{"deleted" => true, "id" => "recJmmAR0IzpaekBn"}
   """
   def delete(%Config.Table{} = table, id) when is_binary(id) do
-    perform_request(table, method: :delete, url_suffix: "/#{id}")
+    perform_request(table, method: :delete, url_suffix: "/" <> id)
+  end
+
+  def delete(%Config.Table{} = table, list) when is_list(list) do
+    params = Enum.reduce(list, [], fn id, acc -> Enum.into(acc, "records[]": id) end)
+
+    perform_request(table, method: :delete, params: params)
   end
 
   @doc """
@@ -134,7 +140,7 @@ defmodule ExAirtable.Service do
       encode(table.base.id) <>
       "/" <>
       encode(table.name) <>
-      encode(suffix)
+      suffix
   end
 
   defp default_headers(%Config.Table{} = table) do

--- a/lib/ex_airtable/table.ex
+++ b/lib/ex_airtable/table.ex
@@ -127,10 +127,14 @@ defmodule ExAirtable.Table do
       end
 
       @doc """
-      Delete a single record (by ID) from an Airtable
+      Delete a single or list of records by ID from an Airtable.
       """
       def delete(id) when is_binary(id) do
         Service.delete(table(), id)
+      end
+
+      def delete(list) when is_list(list) do
+        Service.delete(table(), list)
       end
 
       @doc """

--- a/test/table_cache_test.exs
+++ b/test/table_cache_test.exs
@@ -49,11 +49,27 @@ defmodule ExAirtable.TableCacheTest do
 
   test "delete by ID" do
     TableCache.set(@table_module, "cool", "beans")
+    TableCache.set(@table_module, "hot", "pepper")
     Process.sleep(20)
     assert {:ok, "beans"} = TableCache.retrieve(@table_module, "cool")
+
     TableCache.delete(@table_module, %{"id" => "cool"})
     Process.sleep(100)
     assert {:error, :not_found} = TableCache.retrieve(@table_module, "cool")
+    assert {:ok, "pepper"} = TableCache.retrieve(@table_module, "hot")
+  end
+
+  test "delete by multiple IDs" do
+    TableCache.set(@table_module, "cool", "beans")
+    TableCache.set(@table_module, "hot", "pepper")
+    Process.sleep(20)
+    assert {:ok, "beans"} = TableCache.retrieve(@table_module, "cool")
+    assert {:ok, "pepper"} = TableCache.retrieve(@table_module, "hot")
+
+    TableCache.delete(@table_module, %{"records" => [%{"id" => "cool"}, %{"id" => "hot"}]})
+    Process.sleep(100)
+    assert {:error, :not_found} = TableCache.retrieve(@table_module, "cool")
+    assert {:error, :not_found} = TableCache.retrieve(@table_module, "hot")
   end
 
   test "update existing record" do


### PR DESCRIPTION
I went looking for multiple-records deletes, rather than single record deletes, when I saw extensions being able to delete 50 records at a time. The Airtable API supports deleting 10 records at a time. Rather than, say, defining new `multi_delete` functions, I'm extending the existing `delete` functions to also accept a list of record IDs.

The [documentation](https://airtable.com/developers/web/api/delete-multiple-records) has the following CURL example, which shows the need to use (rather clumsy) multiple `records[]` keys as query parameters:
```
curl -X DELETE "https://api.airtable.com/v0/{baseId}/{tableIdOrName}\
?records[]=rec560UJdUtocSouk&records[]=rec3lbPRG4aVqkeOQ" \
-H "Authorization: Bearer YOUR_TOKEN"
```

I'm using `Enum.into/2` in `ExAirtable.Service` to permit multiple `Keyword` entries with the `"records[]"` key. The use of the `Collectable` protocol is deprecated in favour of `Keyword.merge/2`, but `Enum.into/2` allows repeated binary keys. There may be a better way of doing this. But according to its Hex [documentation](https://hexdocs.pm/httpoison/HTTPoison.Request.html) (for both v1.6.x and 2.2.x versions) `HTTPoison.Request` accepts query parameters as a "map, keyword, or orddict", so we do want to use `Keyword` here.

When playing with the code in the console, `TableCache.delete/2` reported failed deletes when the record IDs were malformed or don't exist in the source table, so I added some defensive code to catch these. But it might make sense to elevate more specific error-checking to `ExAirtable.Service.perform_request/2`.